### PR TITLE
feat: add missing role in seed

### DIFF
--- a/lib/db/seed.ts
+++ b/lib/db/seed.ts
@@ -50,6 +50,7 @@ async function seed() {
       {
         email: email,
         passwordHash: passwordHash,
+        role: "owner",
       },
     ])
     .returning();


### PR DESCRIPTION
Not passing this function prevents the user test@test.com from performing owner actions because the user is left with "member" by default.