### PR TITLE
fix: redirect path from /login to /sign-in

### DIFF
--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -6,7 +6,7 @@ export default async function SettingsPage() {
   const user = await getUser();
 
   if (!user) {
-    redirect('/login');
+    redirect('/sign-in');
   }
 
   const teamData = await getTeamForUser(user.id);


### PR DESCRIPTION
## Description:
`/login` does not exist. The correct path is /sign-in, and this change ensures that the redirection works as intended.