### PR TITLE
Add Stripe login info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ pnpm install
 
 ## Running Locally
 
+Make sure you have Stripe CLI installed, then log in to your Stripe account:
+
+```bash
+stripe login
+```
+
 Use the included setup script to create your `.env` file:
 
 ```bash


### PR DESCRIPTION
Had issues running the setup script without a clear error message. It was something like "Stripe API Key is expired". I figured out it was because I was not logged in to Stripe via their CLI. I suggest adding these lines to README.

EDIT:
Oh I see there is a whole function for that `checkStripeCLI` in the setup. However, that didn't work for me and I was getting confirmation "Stripe CLI is authenticated.", even without being logged in to Stripe CLI.