### PR TITLE
Fix header avatar not tabbable and typo

### DIFF
--- a/app/(dashboard)/dashboard/general/page.tsx
+++ b/app/(dashboard)/dashboard/general/page.tsx
@@ -26,7 +26,7 @@ export default function GeneralPage() {
     // If you call the Server Action directly, it will automatically
     // reset the form. We don't want that here, because we want to keep the
     // client-side values in the inputs. So instead, we use an event handler
-    // which calls the action. You must wrap direct calls with startTranstion.
+    // which calls the action. You must wrap direct calls with startTransition.
     // When you use the `action` prop it automatically handles that for you.
     // Another option here is to persist the values to local storage. I might
     // explore alternative options.

--- a/app/(dashboard)/dashboard/security/page.tsx
+++ b/app/(dashboard)/dashboard/security/page.tsx
@@ -31,7 +31,7 @@ export default function SecurityPage() {
     // If you call the Server Action directly, it will automatically
     // reset the form. We don't want that here, because we want to keep the
     // client-side values in the inputs. So instead, we use an event handler
-    // which calls the action. You must wrap direct calls with startTranstion.
+    // which calls the action. You must wrap direct calls with startTransition.
     // When you use the `action` prop it automatically handles that for you.
     // Another option here is to persist the values to local storage. I might
     // explore alternative options.

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -42,7 +42,7 @@ function Header() {
           </Link>
           {user ? (
             <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
-              <DropdownMenuTrigger asChild>
+              <DropdownMenuTrigger>
                 <Avatar className="cursor-pointer size-9">
                   <AvatarImage alt={user.name || ''} />
                   <AvatarFallback>


### PR DESCRIPTION
1. Fix the avatar dropdown menu not tabbable with the keyboard by removing asChild prop on `DropdownMenuTrigger`
2. Fix typo (`startTranstion`) -> (`startTransition`)

https://github.com/user-attachments/assets/798b0038-a4ef-48eb-9dc5-df382ac6f193

